### PR TITLE
set flashvars to use the new 'auto' streamerType 

### DIFF
--- a/lib/KalturaHelpers.php
+++ b/lib/KalturaHelpers.php
@@ -378,7 +378,7 @@ class KalturaHelpers
 		else
 			$protocol = 'http://';
 
-		$flashVarsStr = '';
+		$flashVarsStr = '"streamerType" : "auto"'; //leverage Kaltura's new automatic protocol selection
 
 		return array(
 			'flashVars' => $flashVarsStr,


### PR DESCRIPTION
This achieves a better streaming experience if the user is running a server that supports more than the progressive download streaming option (e.g. Kaltura.com customers).