### PR TITLE
Settings example without ini parsing

### DIFF
--- a/lib/KalturaHelpers.php
+++ b/lib/KalturaHelpers.php
@@ -284,7 +284,11 @@ class KalturaHelpers
 			return $value;
 
 		if (is_null(self::$_settings))
-			self::$_settings = parse_ini_file(dirname(__FILE__).'/../settings.ini');
+			self::$_settings = apply_filters('kaltura_settings', array(
+				"server_url" => "http://www.kaltura.com",
+				"cdn_url" => "http://cdn.kaltura.com",
+				"anonymous_user_id" => "Anonymous",
+			));
 		$settings = self::$_settings;
 
 		if (isset($settings[$name]))


### PR DESCRIPTION
In most cases users will not edit plugin files directly (editing settings.ini for example).  But this allows Theme authors and others to modify these settings via filters.

I didn't fill out the settings completely, but this should provide an example of how to do this.
