### PR TITLE
Remove output buffer in kalturaGetControllerOutput

### DIFF
--- a/lib/Kaltura/AllInOneVideoPackPlugin.php
+++ b/lib/Kaltura/AllInOneVideoPackPlugin.php
@@ -372,11 +372,6 @@ class Kaltura_AllInOneVideoPackPlugin {
 			global $show_admin_bar;
 			$show_admin_bar = false;
 
-			$controller = new Kaltura_LibraryController();
-			// we want to execute our controller before wordpress starts outputting the html
-			ob_start();
-			$controller->execute();
-			$this->controllerOutput = ob_get_clean();
 			wp_iframe( 'kalturaGetControllerOutput' );
 			die;
 		}
@@ -390,8 +385,8 @@ class Kaltura_AllInOneVideoPackPlugin {
 }
 
 function kalturaGetControllerOutput() {
-	global $kalturaPlugin;
-    echo $kalturaPlugin->controllerOutput;
+	$controller = new Kaltura_LibraryController();
+	$controller->execute();
 }
 
 //style div p button br


### PR DESCRIPTION
We can simplify the logic by outputting the LibraryController HTML directly in `kalturaGetControllerOutput()`.
