### PR TITLE
Changed the call to empty() for backward compatibility with PHP < 5.5…

### DIFF
--- a/lib/Kaltura/LibraryController.php
+++ b/lib/Kaltura/LibraryController.php
@@ -101,7 +101,9 @@ class Kaltura_LibraryController extends Kaltura_BaseController {
 			$width       = KalturaHelpers::getRequestPostParam( 'playerWidth' );
 			$uiConfId    = KalturaHelpers::getRequestPostParam( 'uiConfId' );
 			$playerRatio = KalturaHelpers::getRequestPostParam( 'playerRatio' );
-			$isResponsive = !empty(KalturaHelpers::getRequestPostParam( 'makeResponsive' ));
+
+			$varMakeResponsive = KalturaHelpers::getRequestPostParam( 'makeResponsive' );
+			$isResponsive = !empty($varMakeResponsive);
 
 			$player = $kmodel->getPlayerUiConf( intval($uiConfId) );
 


### PR DESCRIPTION
… (empty can only work on non-variable values in 5.5 upwards)