### PR TITLE
Use native wp_send_json

### DIFF
--- a/lib/Kaltura/LibraryController.php
+++ b/lib/Kaltura/LibraryController.php
@@ -223,7 +223,7 @@ class Kaltura_LibraryController extends Kaltura_BaseController {
 
 	public function getplayersAction() {
 		$players = KalturaHelpers::getAllowedPlayers();
-		echo json_encode( array_values( $players ) );
+		wp_send_json( array_values( $players ) );
 		die;
 	}
 


### PR DESCRIPTION
The native wp_send_json function correctly sets the Content-Type header to `application/json` rather than `text/html`.  This is important for a couple of reasons:

1. The JSON response contains large chunks of XML
2. The XML contains body tags

Without the correct content type header, any tools that might be automatically scanning output can see the embedded body tag and consider the payload to be a web page.  For example, an application monitoring tool like Newrelic is designed to scan all outgoing web pages and inject a performance monitoring javascript after the body tag.  The injected script will render the JSON un-parseable and prevents the video players from loading.

Setting the content type correctly will let any injection scanners know that they shouldn’t interfere with the JSON data stream.
