### PR TITLE
[L10n] Update KalturaHelpers.php - update Thailand name

### DIFF
--- a/lib/KalturaHelpers.php
+++ b/lib/KalturaHelpers.php
@@ -660,7 +660,7 @@ class KalturaHelpers {
 			'TW' => 'Taiwan (台灣)',
 			'TJ' => 'Tajikistan (Тоҷикистон)',
 			'TZ' => 'Tanzania',
-			'TH' => 'Thailand (ราชอาณาจักรไทย)',
+			'TH' => 'Thailand (ประเทศไทย)',
 			'TL' => 'Timor-Leste',
 			'TG' => 'Togo',
 			'TK' => 'Tokelau',


### PR DESCRIPTION
The translation of "Thailand" should be "ประเทศไทย". This is a common form of the country name.

The current translation "ราชอาณาจักรไทย" is only use for the official full form "Kingdom of Thailand".